### PR TITLE
Add a contribuing dev cert of origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # How to contribute
 We ❤️ pull requests. If you'd like to fix a bug, contribute a feature or
 just correct a typo, please feel free to do so, as long as you follow
-our [Code of Conduct](https://github.com/Shopify/graphql-js-schema-fetch/blob/master/CODE_OF_CONDUCT.md).
+our [Code of Conduct](https://github.com/Shopify/graphql-js-schema-fetch/blob/master/CODE_OF_CONDUCT.md)
+and the [Contributing Developer Certificate of Origin](https://github.com/Shopify/graphql-js-schema-fetch/blob/master/CONTRIBUTING_DEVELOPER_CERTIFICATE_OF_ORIGIN.txt).
 
 If you're thinking of adding a big new feature, consider opening an
 issue first to discuss it to ensure it aligns to the direction of the

--- a/CONTRIBUTING_DEVELOPER_CERTIFICATE_OF_ORIGIN.txt
+++ b/CONTRIBUTING_DEVELOPER_CERTIFICATE_OF_ORIGIN.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Bring in line with our open source guidelines. Works toward completing the checklist in https://github.com/Shopify/storefront-api-team-projects/issues/74

@lreeves @swalkinshaw @jzjiang can you please take a look?